### PR TITLE
Adjustment for API consumption

### DIFF
--- a/src/listeners/EntryPointEventListener.js
+++ b/src/listeners/EntryPointEventListener.js
@@ -8,8 +8,9 @@ class EntryPointEventListener {
   }
 
   async start() {
-    var response = await fetch("http://localhost:8081/data");
+    var response = await fetch("http://127.0.0.1:3000/monitor/target/result-sumary/webs?sinceDay=90");
     var targetServices = await response.json();
+
     let html = ejs.render(template, {
       targetServices: targetServices
     });

--- a/src/pages/template_ini.html_
+++ b/src/pages/template_ini.html_
@@ -7,7 +7,7 @@
         </svg>
         <div class="content text-center transform -translate-y-1/2 top-1/2 ml-8 w-72 text-sm object-left"><%=targetService.description%></div>
       </div><span>
-        <div class="text-xl"><%=targetService.label%></div>
+        <div class="text-xl"><%=targetService.webBaseUrl%></div>
       </span>
     </div>
     <div class="pill leading-5 bg-green-200 text-green-800 dark:bg-green-800 dark:text-green-200"><%=targetService.globalStatus%></div>


### PR DESCRIPTION
The endpoint is changed, for the consumption of the api
`./src/listeners/EntryPointEventListener.js`
```javascript
-  var response = await fetch("http://localhost:8081/data");
+  var response = await fetch("http://127.0.0.1:3000/monitor/target/result-sumary/webs?sinceDay=90");
```

The label is changed to webBaseUrl
`./src/pages/template_ini.html_`
```
 -   <div class="text-xl"><%=targetService.label%></div>
 +   <div class="text-xl"><%=targetService.webBaseUrl%></div>
```